### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.3](https://github.com/x-software-com/sancus/compare/v0.1.2...v0.1.3) - 2025-07-07
+
+### Other
+
+- add missing end quote
+- remove no longer needed check
+- *(deps)* bump crate-ci/typos from 1.33.1 to 1.34.0
+
 ## [0.1.2](https://github.com/x-software-com/sancus/compare/v0.1.1...v0.1.2) - 2025-07-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sancus"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sancus"
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/x-software-com/sancus/"
 repository = "https://github.com/x-software-com/sancus/"


### PR DESCRIPTION



## 🤖 New release

* `sancus`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/x-software-com/sancus/compare/v0.1.2...v0.1.3) - 2025-07-07

### Other

- add missing end quote
- remove no longer needed check
- *(deps)* bump crate-ci/typos from 1.33.1 to 1.34.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).