### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.5](https://github.com/x-software-com/sancus/compare/v0.1.4...v0.1.5) - 2025-11-10
+
+### Other
+
+- *(deps)* bump serde_yaml_bw from 2.4.1 to 2.5.1
+- *(deps)* bump crate-ci/typos from 1.38.1 to 1.39.0
+- add cargo machete to commit hooks
+- upgrade dependencies
+- *(deps)* bump clap from 4.5.49 to 4.5.50
+- improve nixos develop experience
+- *(deps)* bump regex from 1.11.3 to 1.12.2
+- *(deps)* bump clap from 4.5.48 to 4.5.49
+- use cocogitto-action v4 instead of main
+- *(deps)* bump flexi_logger from 0.31.6 to 0.31.7
+- *(deps)* bump crate-ci/typos from 1.37.2 to 1.38.1
+
 ## [0.1.4](https://github.com/x-software-com/sancus/compare/v0.1.3...v0.1.4) - 2025-10-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sancus"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sancus"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/x-software-com/sancus/"
 repository = "https://github.com/x-software-com/sancus/"


### PR DESCRIPTION



## 🤖 New release

* `sancus`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/x-software-com/sancus/compare/v0.1.4...v0.1.5) - 2025-11-10

### Other

- *(deps)* bump serde_yaml_bw from 2.4.1 to 2.5.1
- *(deps)* bump crate-ci/typos from 1.38.1 to 1.39.0
- add cargo machete to commit hooks
- upgrade dependencies
- *(deps)* bump clap from 4.5.49 to 4.5.50
- improve nixos develop experience
- *(deps)* bump regex from 1.11.3 to 1.12.2
- *(deps)* bump clap from 4.5.48 to 4.5.49
- use cocogitto-action v4 instead of main
- *(deps)* bump flexi_logger from 0.31.6 to 0.31.7
- *(deps)* bump crate-ci/typos from 1.37.2 to 1.38.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).