### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.1.7](https://github.com/x-software-com/sancus/compare/v0.1.6...v0.1.7) - 2025-12-03
+
+### Other
+
+- update dependencies
+- *(deps)* bump crate-ci/typos from 1.39.2 to 1.40.0
+- add feature to scan for licenses and create a JSON-SPDX file
+- default features of all dependencies disabled
+
 ## [0.1.6](https://github.com/x-software-com/sancus/compare/v0.1.5...v0.1.6) - 2025-11-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sancus"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sancus"
-version = "0.1.6"
+version = "0.1.7"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/x-software-com/sancus/"
 repository = "https://github.com/x-software-com/sancus/"


### PR DESCRIPTION



## 🤖 New release

* `sancus`: 0.1.6 -> 0.1.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/x-software-com/sancus/compare/v0.1.6...v0.1.7) - 2025-12-03

### Other

- update dependencies
- *(deps)* bump crate-ci/typos from 1.39.2 to 1.40.0
- add feature to scan for licenses and create a JSON-SPDX file
- default features of all dependencies disabled
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).