### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## [0.2.0](https://github.com/x-software-com/sancus/compare/v0.1.7...v0.2.0) - 2026-01-21
+
+### Other
+
+- *(deps)* bump crate-ci/typos from 1.40.0 to 1.42.0
+- fix clippy issues
+- upgrade dependencies and rust-version
+- improved rpm query
+- add missing feature
+
 ## [0.1.7](https://github.com/x-software-com/sancus/compare/v0.1.6...v0.1.7) - 2025-12-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sancus"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sancus"
-version = "0.1.7"
+version = "0.2.0"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/x-software-com/sancus/"
 repository = "https://github.com/x-software-com/sancus/"


### PR DESCRIPTION



## 🤖 New release

* `sancus`: 0.1.7 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `sancus` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sancus_lib::rpm_info::package_info, previously in file /tmp/.tmpaW56d2/sancus/src/rpm_info.rs:175
  function sancus_lib::rpm_info::package_name_of_lib, previously in file /tmp/.tmpaW56d2/sancus/src/rpm_info.rs:99
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/x-software-com/sancus/compare/v0.1.7...v0.2.0) - 2026-01-21

### Other

- *(deps)* bump crate-ci/typos from 1.40.0 to 1.42.0
- fix clippy issues
- upgrade dependencies and rust-version
- improved rpm query
- add missing feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).